### PR TITLE
Make package loadable on systems without oneAPI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KrylovPreconditioners"
 uuid = "45d422c2-293f-44ce-8315-2cb988662dec"
 authors = ["Alexis Montoison <alexis.montoison@polymtl.ca>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/KrylovPreconditionersOneAPIExt.jl
+++ b/ext/KrylovPreconditionersOneAPIExt.jl
@@ -1,19 +1,23 @@
 module KrylovPreconditionersOneAPIExt
-using LinearAlgebra
-using SparseArrays
 using oneAPI
-using oneAPI: global_queue, sycl_queue, context, device
-using oneAPI.oneMKL
-using LinearAlgebra: checksquare, BlasReal, BlasFloat
-import LinearAlgebra: ldiv!, mul!
-import Base: size, eltype, unsafe_convert
 
-using KrylovPreconditioners
-const KP = KrylovPreconditioners
-using KernelAbstractions
-const KA = KernelAbstractions
+# Don't do anything if oneAPI isn't actually available.
+if oneAPI.oneL0.NEO_jll.is_available() && oneAPI.oneL0.functional[]
+    using oneAPI: global_queue, sycl_queue, context, device
+    using LinearAlgebra
+    using SparseArrays
+    using oneAPI.oneMKL
+    using LinearAlgebra: checksquare, BlasReal, BlasFloat
+    import LinearAlgebra: ldiv!, mul!
+    import Base: size, eltype, unsafe_convert
 
-include("oneAPI/block_jacobi.jl")
-include("oneAPI/operators.jl")
+    using KrylovPreconditioners
+    const KP = KrylovPreconditioners
+    using KernelAbstractions
+    const KA = KernelAbstractions
+
+    include("oneAPI/block_jacobi.jl")
+    include("oneAPI/operators.jl")
+end
 
 end


### PR DESCRIPTION
At the moment it's impossible to load this package in an environment with `oneAPI.jl`, if oneAPI isn't actually available (e.g. on aarch64 machines), which breaks lots of downstream workflows.  For reference, this is the same change as https://github.com/JuliaGPU/oneAPI.jl/pull/493/files?w=1.

Please tag a new version after merging this PR.