### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,7 @@ steps:
       - JuliaCI/julia#v1:
           version: "1.10"
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     command: |
       julia --color=yes --project=test/gpu -e '
         using Pkg
@@ -22,8 +21,7 @@ steps:
       - JuliaCI/julia#v1:
           version: "1.10"
     agents:
-      queue: "juliagpu"
-      rocm: "*"
+      queue: "rocm"
       rocmgpu: "*"
     env:
       JULIA_NUM_THREADS: 4
@@ -46,8 +44,7 @@ steps:
       - JuliaCI/julia#v1:
           version: "1.10"
     agents:
-      queue: "juliagpu"
-      intel: "*"
+      queue: "oneapi"
     command: |
       julia --color=yes --project=test/gpu -e '
         using Pkg


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)